### PR TITLE
Cardata: prefer charging.status over charging.hvStatus

### DIFF
--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,15 +190,15 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
-	if err != nil || hv == "" || hv == "INVALID" {
-		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
+	cs, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
+	if err != nil || cs == "" {
+		cs, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}
 
 	if slices.Contains([]string{
-		"CHARGING",       // vehicle.drivetrain.electricEngine.charging.hvStatus
 		"CHARGINGACTIVE", // vehicle.drivetrain.electricEngine.charging.status
-	}, hv) {
+		"CHARGING",       // vehicle.drivetrain.electricEngine.charging.hvStatus
+	}, cs) {
 		return api.StatusC, nil
 	}
 

--- a/vehicle/bmw/cardata/provider.go
+++ b/vehicle/bmw/cardata/provider.go
@@ -190,9 +190,9 @@ func (v *Provider) Status() (api.ChargeStatus, error) {
 		status = api.StatusB
 	}
 
-	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
+	hv, err := v.String("vehicle.drivetrain.electricEngine.charging.status")
 	if err != nil || hv == "" || hv == "INVALID" {
-		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.status")
+		hv, err = v.String("vehicle.drivetrain.electricEngine.charging.hvStatus")
 	}
 
 	if slices.Contains([]string{


### PR DESCRIPTION
hvStatus seems to be only provided through the telematics rest API, not mqtt, and thus, is sometimes outdated. To make sure to prefer the most up to date values, prefer status. Should fix #25103.